### PR TITLE
Add pod anti-affinity default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The values are split into two sections:
 | podAnnotations | object | `{}` | Annotations for SCIM bridge pod. |
 | podLabels | object | `{}` | Labels for SCIM bridge pod. |
 | nodeSelector | object | `{}` | Node selector for SCIM bridge pod. |
-| affinity | object | `{}` | Affinity for SCIM bridge pod. |
+| affinity | object | `{ "podAntiAffinity": {} }` | Affinity for SCIM bridge pod. By default we configure pod anti-affinity to ensure redis and SCIM bridge pods are not scheduled on the same node. |
 | tolerations | list | `[]` | Tolerations for SCIM bridge pod. |
 
 #### config
@@ -122,5 +122,6 @@ This is a small subset of possible the values that you can configure for Redis. 
 | image | object | `{ "registry": "docker.io", "repository": "bitnami/redis", "tag": "latest", "pullPolicy": "IfNotPreset" }` | Use the latest `bitnami/redis` image from `docker.io` and pull the image if it is not present. |
 | cluster | object | `{"enabled": false }` | Redis cluster is disabled by default. |
 | usePassword | bool | `false` | Use password is disabled by default. |
+| master.affinity | object | `{ "affinity": "podAntiAffinity": {} }` | Master affinity. By default we configure pod anti-affinity to ensure redis and SCIM bridge pods are not scheduled on the same node. Note that this configuration should be duplicated for the slave when not running redis in standalone mode. |
 
 

--- a/op-scim-bridge/templates/deployment.yaml
+++ b/op-scim-bridge/templates/deployment.yaml
@@ -33,15 +33,15 @@ spec:
         {{ toYaml . | nindent 8 }}
       {{ end }}
     spec:
-      {{ with .Values.nodeSelector }}
+      {{ with .Values.scim.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
       {{ end }}
-      {{ with .Values.affinity }}
+      {{ with .Values.scim.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
       {{ end }}
-      {{ with .Values.tolerations }}
+      {{ with .Values.scim.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{ end }}

--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -101,7 +101,7 @@ redis:
     enabled: false
   usePassword: false
   # prefer to schedule redis and SCIM bridge pods on separate nodes
-  # this configuarion should be duplicated for replica.affinity when not running redis as a standalone instance
+  # this configuration should be duplicated for replica.affinity when not running redis as a standalone instance
   master:
     affinity:
       podAntiAffinity:

--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -79,7 +79,13 @@ scim:
   # nodeSelector sets the node selector for the SCIM bridge pod
   nodeSelector: {}
   # affinity sets the affinity for the SCIM bridge pod
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app: "redis"
+          topologyKey: topology.kubernetes.io/zone
   # tolerations sets the tolerations for the SCIM bridge pod
   tolerations: []
 
@@ -94,6 +100,16 @@ redis:
   cluster:
     enabled: false
   usePassword: false
+  # prefer to schedule redis and SCIM bridge pods on separate nodes
+  # this configuarion should be duplicated for replica.affinity when not running redis as a standalone instance
+  master:
+    affinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app: "op-scim-bridge"
+            topologyKey: topology.kubernetes.io/zone
 
 # acceptanceTests is used by the tests run during CI (see op-scim-bridge/templates/tests)
 acceptanceTests:

--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -84,7 +84,7 @@ scim:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchLabels:
-              app: "redis"
+              app: redis
           topologyKey: topology.kubernetes.io/zone
   # tolerations sets the tolerations for the SCIM bridge pod
   tolerations: []
@@ -108,7 +108,7 @@ redis:
         requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels:
-                app: "op-scim-bridge"
+                app: op-scim-bridge
             topologyKey: topology.kubernetes.io/zone
 
 # acceptanceTests is used by the tests run during CI (see op-scim-bridge/templates/tests)


### PR DESCRIPTION
In this PR we add default values for pod anti-affinity.

The purpose of this change is to request that the Kubernetes scheduler ensures that the SCIM bridge pods and the redis pods are not scheduled on the same node. This is done to ensure that resource utilization by either application does not starve or affect the other. See the Kubernetes documentation for more details: [Inter-pod affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity).

Note that this configuration requires that a minimum node count of 2. This is already the requirement for our one-click deployments.

As a side note, I also noticed a bug where we were not specifying the full values key for the `deployment.yaml`. This was also fixed as part of the changes.

To test I recommend that you deploy this configuration to your favourite cloud provider, and ensure that the pod anti-affinity settings are applied to both SCIM bridge and redis pods, and to make sure that they are indeed scheduled on different nodes as desired.

Example package and install command:
```
helm package op-scim-bridge && \
helm install op-scim-bridge op-scim-2.3.0.tgz --create-namespace --namespace op-scim-bridge
```

Example delete command:
```
helm delete op-scim-bridge --namespace op-scim-bridge
```

Resolves #37.

The reference issue isn't exactly the same as the changes described here, but it solves the same problem in a better way.