### PR TITLE
Fix generated YAML whitespace

### DIFF
--- a/op-scim-bridge/templates/deployment.yaml
+++ b/op-scim-bridge/templates/deployment.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: {{ tpl .Values.scim.name . }}
-    {{ with .Values.scim.labels }}
-      {{ toYaml . | nindent 4 }}
-    {{ end }}
-  {{ with .Values.scim.annotations }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.scim.annotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
-  {{ end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -25,33 +25,33 @@ spec:
         app: {{ tpl .Values.scim.name . }}
         version: {{ tpl .Values.scim.version . }}
         app.kubernetes.io/component: {{ tpl .Values.scim.name . }}
-        {{ with .Values.scim.podLabels }}
-          {{ toYaml . | nindent 8 }}
-        {{ end }}
-      {{ with .Values.scim.podAnnotations }}
+        {{- with .Values.scim.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.scim.podAnnotations }}
       annotations:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
-      {{ with .Values.scim.nodeSelector }}
+      {{- with .Values.scim.nodeSelector }}
       nodeSelector:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ with .Values.scim.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scim.affinity }}
       affinity:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ with .Values.scim.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scim.tolerations }}
       tolerations:
-        {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ if .Values.scim.credentialsVolume }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.scim.credentialsVolume }}
       volumes:
         - name: {{ tpl .Values.scim.credentialsVolume.name . }}
           persistentVolumeClaim:
             claimName: {{ tpl .Values.scim.name . }}-pvc
-      {{ end }}
-      {{ if .Values.scim.credentialsVolume }}
+      {{- end }}
+      {{- if .Values.scim.credentialsVolume }}
       initContainers:
         - name: opuser-home-permissions
           image: alpine:3.12
@@ -63,7 +63,7 @@ spec:
           volumeMounts:
             - mountPath: /home/opuser/.op
               name: {{ tpl .Values.scim.name . }}-credentials
-      {{ end }}
+      {{- end }}
       containers:
         - name: {{ tpl .Values.scim.name . }}
           image: {{ .Values.scim.imageRepository }}:{{ tpl .Values.scim.version . }}
@@ -73,55 +73,55 @@ spec:
             runAsUser: 999
             runAsGroup: 999
             allowPrivilegeEscalation: false
-          {{ with .Values.scim.imagePullSecrets }}
+          {{- with .Values.scim.imagePullSecrets }}
           imagePullSecrets:
-            {{ toYaml . | nindent 12 }}
-          {{ end }}
-          {{ with .Values.scim.resources }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.scim.resources }}
           resources:
-            {{ toYaml . | nindent 12 }}
-          {{ end }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: "OP_PORT"
               value: "{{ .Values.scim.httpPort }}"
             - name: "OP_SESSION"
-              {{ if .Values.scim.credentialsVolume }}
+              {{- if .Values.scim.credentialsVolume }}
               value: "/home/opuser/.op/{{ .Values.scim.credentialsVolume.file }}"
-              {{ end }}
-              {{ if .Values.scim.credentialsSecret }}
+              {{- end }}
+              {{- if .Values.scim.credentialsSecret }}
               valueFrom:
                 secretKeyRef:
                   name: {{ tpl .Values.scim.credentialsSecret.name . }}
                   key: {{ .Values.scim.credentialsSecret.key }}
-              {{ end }}
+              {{- end }}
             - name: "OP_REDIS_URL"
               value: "{{ tpl .Values.scim.config.redisURL . }}"
             - name: "OP_PING_SERVER"
               value: "{{ .Values.scim.probes.liveness.enabled }}"
-            {{ if .Values.scim.config.letsEncryptDomain }}
+            {{- if .Values.scim.config.letsEncryptDomain }}
             - name: "OP_LETSENCRYPT_DOMAIN"
               value: "{{ .Values.scim.config.letsEncryptDomain }}"
-            {{ end }}
-            {{ if .Values.scim.config.domain }}
+            {{- end }}
+            {{- if .Values.scim.config.domain }}
             - name: "OP_DOMAIN"
               value: {{ .Values.scim.config.domain }}
-            {{ end }}
-            {{ if .Values.scim.config.debug }}
+            {{- end }}
+            {{- if .Values.scim.config.debug }}
             - name: "OP_DEBUG"
               value: {{ .Values.scim.config.debug }}
-            {{ end }}
-            {{ if .Values.scim.config.jsonLogs }}
+            {{- end }}
+            {{- if .Values.scim.config.jsonLogs }}
             - name: "OP_JSON_LOGS"
               value: {{ .Values.scim.config.jsonLogs }}
-            {{ end }}
-            {{ if .Values.scim.config.prettyLogs }}
+            {{- end }}
+            {{- if .Values.scim.config.prettyLogs }}
             - name: "OP_PRETTY_LOGS"
               value: {{ .Values.scim.config.prettyLogs }}
-            {{ end }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.scim.httpPort }}
             - containerPort: {{ .Values.scim.httpsPort }}
-          {{ if .Values.scim.probes.liveness.enabled }}
+          {{- if .Values.scim.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
               path: {{ .Values.scim.probes.liveness.path }}
@@ -130,10 +130,10 @@ spec:
             failureThreshold: 3
             periodSeconds: 30
             initialDelaySeconds: 15
-          {{ end }}
-          {{ if .Values.scim.credentialsVolume }}
+          {{- end }}
+          {{- if .Values.scim.credentialsVolume }}
           volumeMounts:
             - name: {{ tpl .Values.scim.name . }}-credentials
               mountPath: "/home/opuser/.op"
               readOnly: false
-          {{ end }}
+          {{- end }}

--- a/op-scim-bridge/templates/persistentvolumeclaim.yaml
+++ b/op-scim-bridge/templates/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.scim.credentialsVolume }}
+{{- if .Values.scim.credentialsVolume }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -6,27 +6,27 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/application: {{ tpl .Values.scim.name . }}
-    {{ with .Values.scim.labels }}
-      {{ toYaml . | nindent 4 }}
-    {{ end }}
-  {{ with .Values.scim.annotations }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.scim.annotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
-  {{ end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  {{ with .Values.scim.credentialsVolume.accessModes }}
+  {{- with .Values.scim.credentialsVolume.accessModes }}
   accessModes:
-    {{ toYaml . | nindent 4 }}
-  {{ end }}
-  {{ with .Values.scim.credentialsVolume.resources }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.scim.credentialsVolume.resources }}
   resources:
-    {{ toYaml . | nindent 4 }}
-  {{ end }}
-{{ if .Values.scim.credentialsVolume.storageClass }}
-  {{ if (eq "-" .Values.scim.credentialsVolume.storageClass) }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if .Values.scim.credentialsVolume.storageClass }}
+  {{- if (eq "-" .Values.scim.credentialsVolume.storageClass) }}
   storageClassName: '""'
-  {{ else }}
+  {{- else }}
   storageClassName: "{{ .Values.scim.credentialsVolume.storageClass }}"
-  {{ end }}
-{{ end }}
-{{ end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/op-scim-bridge/templates/secret.yaml
+++ b/op-scim-bridge/templates/secret.yaml
@@ -1,8 +1,8 @@
-{{ if .Values.scim.credentialsSecret }}
-{{ if or .Values.scim.credentialsSecret.value_json .Values.scim.credentialsSecret.value_base64 }}
-{{ if and .Values.scim.credentialsSecret.value_json .Values.scim.credentialsSecret.value_base64 }}
-  {{ fail "Only one of scim.credentialsSecret.value_json and scim.credentialsSecret.value_base64 can be specified" }}
-{{ end }}
+{{- if .Values.scim.credentialsSecret }}
+{{- if or .Values.scim.credentialsSecret.value_json .Values.scim.credentialsSecret.value_base64 }}
+{{- if and .Values.scim.credentialsSecret.value_json .Values.scim.credentialsSecret.value_base64 }}
+  {{- fail "Only one of scim.credentialsSecret.value_json and scim.credentialsSecret.value_base64 can be specified" }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -20,10 +20,10 @@ metadata:
 type: Opaque
 stringData:
   {{ .Values.scim.credentialsSecret.key }}: |-
-  {{ if .Values.scim.credentialsSecret.value_json }}
+  {{- if .Values.scim.credentialsSecret.value_json }}
   {{- .Values.scim.credentialsSecret.value_json | b64enc | indent 2 }}
-  {{ else }}
+  {{- else }}
   {{- .Values.scim.credentialsSecret.value_base64 | indent 2 }}
-  {{ end }}
-{{ end }}
-{{ end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/op-scim-bridge/templates/secret.yaml
+++ b/op-scim-bridge/templates/secret.yaml
@@ -20,10 +20,10 @@ metadata:
 type: Opaque
 stringData:
   {{ .Values.scim.credentialsSecret.key }}: |-
-  {{- if .Values.scim.credentialsSecret.value_json }}
+  {{ if .Values.scim.credentialsSecret.value_json }}
   {{- .Values.scim.credentialsSecret.value_json | b64enc | indent 2 }}
-  {{- else }}
+  {{ else }}
   {{- .Values.scim.credentialsSecret.value_base64 | indent 2 }}
-  {{- end }}
+  {{ end }}
 {{- end }}
 {{- end }}

--- a/op-scim-bridge/templates/secret.yaml
+++ b/op-scim-bridge/templates/secret.yaml
@@ -10,20 +10,20 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/application: {{ tpl .Values.scim.name . }}
-    {{ with .Values.scim.labels }}
-      {{ toYaml . | nindent 4 }}
-    {{ end }}
-  {{ with .Values.scim.annotations }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.scim.annotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
-  {{ end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: Opaque
 stringData:
   {{ .Values.scim.credentialsSecret.key }}: |-
   {{ if .Values.scim.credentialsSecret.value_json }}
-  {{ .Values.scim.credentialsSecret.value_json | b64enc | indent 2 }}
+  {{- .Values.scim.credentialsSecret.value_json | b64enc | indent 2 }}
   {{ else }}
-  {{ .Values.scim.credentialsSecret.value_base64 | indent 2 }}
+  {{- .Values.scim.credentialsSecret.value_base64 | indent 2 }}
   {{ end }}
 {{ end }}
 {{ end }}

--- a/op-scim-bridge/templates/service.yaml
+++ b/op-scim-bridge/templates/service.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: {{ tpl .Values.scim.name . }}
-    {{ with .Values.scim.labels }}
-      {{ toYaml . | nindent 4 }}
-    {{ end }}
-  {{ with .Values.scim.annotations }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.scim.annotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
-  {{ end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.scim.serviceType }}
   selector:

--- a/op-scim-bridge/templates/tests/auth.yaml
+++ b/op-scim-bridge/templates/tests/auth.yaml
@@ -5,15 +5,15 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: {{ tpl .Values.scim.name . }}
-    {{ with .Values.scim.labels }}
-      {{ toYaml . | nindent 4 }}
-    {{ end }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "1"
-    {{ with .Values.scim.annotations }}
-      {{ toYaml . | nindent 4 }}
-    {{ end }}
+    {{- with .Values.scim.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   restartPolicy: Never
   containers:

--- a/op-scim-bridge/templates/tests/ping.yaml
+++ b/op-scim-bridge/templates/tests/ping.yaml
@@ -5,15 +5,15 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/component: {{ tpl .Values.scim.name . }}
-    {{ with .Values.scim.labels }}
-      {{ toYaml . | nindent 4 }}
-    {{ end }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     helm.sh/hook: test
     helm.sh/hook-weight: "1"
-    {{ with .Values.scim.annotations }}
-      {{ toYaml . | nindent 4 }}
-    {{ end }}
+    {{- with .Values.scim.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   restartPolicy: Never
   containers:


### PR DESCRIPTION
This PR removes unnecessary whitespace from the generated YAML. There are no functional changes in this PR.

Most of these fixes are basically including a `-` in the template variables, i.e. updating `{{ ...  }}` to `{{- ... }}`.

To test, I recommend running the Helm install command with the `--dry-run` and  `--debug` flags, for example:
```
helm package op-scim-bridge && \
helm install op-scim-bridge op-scim-2.3.0.tgz --create-namespace --namespace op-scim-bridge --dry-run --debug > helm_output.yaml
```
This command does a dry run of the install command with debug enabled and stores the output in a file called `./helm_output.yaml`.

Inspecting the YAML for any unexpected new lines in the generated output.

Resolves #34.