### PR TITLE
Resources for init containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The values are split into two sections:
 | nodeSelector | object | `{}` | Node selector for SCIM bridge pod. |
 | affinity | object | `{ "podAntiAffinity": {} }` | Affinity for SCIM bridge pod. By default we configure pod anti-affinity to ensure redis and SCIM bridge pods are not scheduled on the same node. |
 | tolerations | list | `[]` | Tolerations for SCIM bridge pod. |
-| init| object | `{}`| Resources for init containers|
+| initContainers | object | `{}` | Configuration options for init containers. |
 
 #### config
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The values are split into two sections:
 | nodeSelector | object | `{}` | Node selector for SCIM bridge pod. |
 | affinity | object | `{ "podAntiAffinity": {} }` | Affinity for SCIM bridge pod. By default we configure pod anti-affinity to ensure redis and SCIM bridge pods are not scheduled on the same node. |
 | tolerations | list | `[]` | Tolerations for SCIM bridge pod. |
+| init| object | `{}`| Resources for init containers|
 
 #### config
 

--- a/op-scim-bridge/templates/deployment.yaml
+++ b/op-scim-bridge/templates/deployment.yaml
@@ -63,6 +63,10 @@ spec:
           volumeMounts:
             - mountPath: /home/opuser/.op
               name: {{ tpl .Values.scim.name . }}-credentials
+          {{ with .Values.scim.initContainers.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       containers:
         - name: {{ tpl .Values.scim.name . }}

--- a/op-scim-bridge/templates/deployment.yaml
+++ b/op-scim-bridge/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           volumeMounts:
             - mountPath: /home/opuser/.op
               name: {{ tpl .Values.scim.name . }}-credentials
-      {{ end }}
+      {{- end }}
       containers:
         - name: {{ tpl .Values.scim.name . }}
           image: {{ .Values.scim.imageRepository }}:{{ tpl .Values.scim.version . }}

--- a/op-scim-bridge/templates/deployment.yaml
+++ b/op-scim-bridge/templates/deployment.yaml
@@ -63,6 +63,10 @@ spec:
           volumeMounts:
             - mountPath: /home/opuser/.op
               name: {{ tpl .Values.scim.name . }}-credentials
+          {{ with .Values.scim.init.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{ end }}
       {{ end }}
       containers:
         - name: {{ tpl .Values.scim.name . }}

--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -88,7 +88,8 @@ scim:
           topologyKey: topology.kubernetes.io/zone
   # tolerations sets the tolerations for the SCIM bridge pod
   tolerations: []
-
+  init:
+    resources: {}
 # redis configuration options (see upstream chart documentation and README.MD)
 redis:
   enabled: true

--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -88,7 +88,8 @@ scim:
           topologyKey: topology.kubernetes.io/zone
   # tolerations sets the tolerations for the SCIM bridge pod
   tolerations: []
-  init:
+  # initContainers sets config options for the init containers
+  initContainers:
     resources: {}
 # redis configuration options (see upstream chart documentation and README.MD)
 redis:


### PR DESCRIPTION
Resources are being assigned only to regular pod. This makes op-scim-bridge impossible to deploy in any namespace with already assigned resources.
Adding scim.init section (for possible future changes for init-containers) fixes this.