### PR TITLE
Wrap boolean environment variables in quotes

### DIFF
--- a/op-scim-bridge/templates/deployment.yaml
+++ b/op-scim-bridge/templates/deployment.yaml
@@ -112,15 +112,15 @@ spec:
             {{- end }}
             {{- if .Values.scim.config.debug }}
             - name: "OP_DEBUG"
-              value: {{ .Values.scim.config.debug }}
+              value: "{{ .Values.scim.config.debug }}"
             {{- end }}
             {{- if .Values.scim.config.jsonLogs }}
             - name: "OP_JSON_LOGS"
-              value: {{ .Values.scim.config.jsonLogs }}
+              value: "{{ .Values.scim.config.jsonLogs }}"
             {{- end }}
             {{- if .Values.scim.config.prettyLogs }}
             - name: "OP_PRETTY_LOGS"
-              value: {{ .Values.scim.config.prettyLogs }}
+              value: "{{ .Values.scim.config.prettyLogs }}"
             {{- end }}
           ports:
             - containerPort: {{ .Values.scim.httpPort }}


### PR DESCRIPTION
This PR addresses the issue reported in #42.

Thank you to @@Kristianwhittick for raising the issue! 🙌

I tested the changes by deploying the config to Digital Ocean and enabling both `OP_DEBUG` and `OP_PRETTY_LOGS`.

Closes #42.