### PR TITLE
Chart improvements

### DIFF
--- a/op-scim-bridge/templates/deployment.yaml
+++ b/op-scim-bridge/templates/deployment.yaml
@@ -16,7 +16,9 @@ spec:
   selector:
     matchLabels:
       app: {{ tpl .Values.scim.name . }}
-  replicas: 1
+  {{- if not .Values.scim.autoscaling.enabled }}
+  replicas: {{ .Values.scim.replicaCount }}
+  {{- end }}
   strategy:
     type: Recreate
   template:
@@ -33,6 +35,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.scim.serviceAccount.name }}
+      serviceAccountName: {{ .Values.scim.serviceAccount.name }}
+      {{- else }}
+      serviceAccountName: {{ tpl .Values.scim.name . }}
+      {{- end }}
       {{- with .Values.scim.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/op-scim-bridge/templates/horizontalPodAutoscaler.yaml
+++ b/op-scim-bridge/templates/horizontalPodAutoscaler.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.scim.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ tpl .Values.scim.name . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ tpl .Values.scim.name . }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ tpl .Values.scim.name . }}
+  minReplicas: {{ .Values.scim.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.scim.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.scim.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.scim.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.scim.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.scim.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/op-scim-bridge/templates/ingress.yaml
+++ b/op-scim-bridge/templates/ingress.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.scim.ingress.enabled -}}
+{{- $name := tpl .Values.scim.name . -}}
+{{- if and .Values.scim.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.scim.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.scim.ingress.annotations "kubernetes.io/ingress.class" .Values.scim.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ $name }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.scim.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.scim.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.scim.ingress.className }}
+  {{- end }}
+  {{- if .Values.scim.ingress.tls }}
+  tls:
+    {{- range .Values.scim.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.scim.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: "{{$name}}-svc"
+                port:
+                  number: 80
+              {{- else }}
+              serviceName: "{{$name}}-svc"
+              servicePort: 80
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/op-scim-bridge/templates/podDisruptionBudget.yaml
+++ b/op-scim-bridge/templates/podDisruptionBudget.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.scim.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ tpl .Values.scim.name . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ tpl .Values.scim.name . }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  minAvailable: {{ .Values.scim.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ tpl .Values.scim.name . }}
+{{- end }}

--- a/op-scim-bridge/templates/serviceAccount.yaml
+++ b/op-scim-bridge/templates/serviceAccount.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.scim.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- if .Values.scim.serviceAccount.name }}
+  name: {{ .Values.scim.serviceAccount.name }}
+  {{- else }}
+  name: {{ tpl .Values.scim.name . }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ tpl .Values.scim.name . }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.scim.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/op-scim-bridge/templates/serviceMonitor.yaml
+++ b/op-scim-bridge/templates/serviceMonitor.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.scim.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ tpl .Values.scim.name . }}
+  {{- if .Values.scim.serviceMonitor.namespace }}
+  namespace: {{ .Values.scim.serviceAccount.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/component: {{ tpl .Values.scim.name . }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: {{ tpl .Values.scim.name . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: http
+    path: /metrics
+{{- end }}

--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -88,6 +88,49 @@ scim:
           topologyKey: topology.kubernetes.io/zone
   # tolerations sets the tolerations for the SCIM bridge pod
   tolerations: []
+  # replicaCount sets number of replicas to deploy
+  replicaCount: 1
+  # autoscaling if enabled creates a HorizontalPodAutoscaler resource. Will override replicaCount
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  # podDisruptionBudget if enabled creates a podDisruptionBudget resource. 
+  # require more than 1 replica or autoscaling enabled to be effective.
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    annotations: {}
+  # Service Account to use. If using externally created 
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+      # - host: chart-example.local
+      #   paths:
+      #     - path: /
+      #       pathType: ImplementationSpecific
+    tls: []
+      #  - secretName: chart-example-tls
+      #    hosts:
+      #      - chart-example.local
+  # serviceMonitor if enabled create prometheus ServiceMonitor for auto discovery
+  serviceMonitor:
+    enabled: false
+    # namespace to deploy the service monitor to. Usually should match the namespace Prometheus Operator is deployed at
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/getting-started.md
+    namespace: ""
   # initContainers sets config options for the init containers
   initContainers:
     resources: {}


### PR DESCRIPTION
To make the chart a bit more "Production" ready and support environments that enforce high availability and zero downtime I've added some functionality that may be useful for a lot of people.

This PR is almost 1:1 of the one I use at the moment and I hope to switch to the official helm chart once this PR is approved.

Changes in this PR:
- Use of dedicated ServiceAcount instead of the default service account for added security (scim does not need access to cluster resources)
- Ability to control the number of replicas to deploy for HA
- Optional use of HorizontalPodAutoscaler
- Optional use of PodDisruptionBudget
- Optional use of external Ingress
- Optional use of ServiceMonitor for Prometheus Operator auto-discovery of the new `/metrics` endpoint