### PR TITLE
Set resource requests and limits for SCIM bridge and Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,5 @@ This is a small subset of possible the values that you can configure for Redis. 
 | cluster | object | `{"enabled": false }` | Redis cluster is disabled by default. |
 | usePassword | bool | `false` | Use password is disabled by default. |
 | master.affinity | object | `{ "affinity": "podAntiAffinity": {} }` | Master affinity. By default we configure pod anti-affinity to ensure redis and SCIM bridge pods are not scheduled on the same node. Note that this configuration should be duplicated for the slave when not running redis in standalone mode. |
+| master.resources | object | `{}` | Master resource requests and limits. |
+| master.extraFlags | object | `{}` | Master extra flags. By default set a maximum memory limit and define the policy to use when key eviction is required. |

--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -82,7 +82,13 @@ scim:
     enabled: false
     secret: "{{ .Chart.Name }}-bridge-tls"
   # resource sets the requests and/or limits for the SCIM bridge pod
-  resources: {}
+  resources:
+    requests:
+      cpu: 125m
+      memory: 256M
+    limits:
+      cpu: 250m
+      memory: 512M
   # annotations adds additional annotations
   annotations: {}
   # labels adds additional labels

--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -164,6 +164,13 @@ redis:
               matchLabels:
                 app: op-scim-bridge
             topologyKey: topology.kubernetes.io/zone
+    resources:
+      requests:
+        cpu: 125m
+        memory: 256M
+      limits:
+        cpu: 250m
+        memory: 512M
 
 # acceptanceTests is used by the tests run during CI (see op-scim-bridge/templates/tests)
 acceptanceTests:

--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -171,6 +171,9 @@ redis:
       limits:
         cpu: 250m
         memory: 512M
+    extraFlags:
+      - "--maxmemory 256mb"
+      - "--maxmemory-policy volatile-lru"
 
 # acceptanceTests is used by the tests run during CI (see op-scim-bridge/templates/tests)
 acceptanceTests:


### PR DESCRIPTION
In this PR we set resource requests and limits for the SCIM bridge and Redis application pods.

We also set a max memory limit for Redis before the Redis server will start evicting keys based on the selected policy.

I tested this by deploying the changes to DO and GCP and inspecting the deployments to ensure that the config was applied correctly.

Resolves #36. 