### PR TITLE
Fix Redis URL value

### DIFF
--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -67,7 +67,7 @@ scim:
   # config sets the configuration options
   config:
     # redisURL sets the Redis connection URL
-    redisURL: "redis://{{ .Release.Namespace }}-redis-master:6379"
+    redisURL: "redis://{{ .Chart.Name }}-bridge-redis-master:6379"
     # domain sets the allowed 1Password sign in URL. Not set by default.
     # domain: example.1password.com
     # letsEncryptDomain sets the domain to attempt to get a certificate for via Let's Encrypt.


### PR DESCRIPTION
This PR sets the redisURL value using the chart value instead of the namespace.

Closes https://github.com/1Password/op-scim-helm/issues/53.