### PR TITLE
Update action to run on PR into main branch

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,6 +1,8 @@
 name: Lint and test charts
 on:
-  push:
+  pull_request:
+    branches:
+      - "main"
 
   # Workflow dispatch listener to enable on-demand acceptance test runs on external PRs.
   # How to use this:


### PR DESCRIPTION
We have had a few PRs submitted by folks outside the provisioning team. In these cases the required GitHub actions didn't run and resulted in the merge of the PR being blocked.

In this PR we change the action to run when a PR into main is opened, reopened or updated.