### PR TITLE
Revert action trigger change

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -1,8 +1,6 @@
 name: Lint and test charts
 on:
-  pull_request:
-    branches:
-      - "main"
+  push:
 
   # Workflow dispatch listener to enable on-demand acceptance test runs on external PRs.
   # How to use this:

--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -6,7 +6,7 @@ on:
   # How to use this:
   # * Do a sanity check on the submitted PR
   # * Copy the most recent commit hash of the PR branch
-  # * Go to 'Actions' -> 'Run acceptance tests' -> 'Run workflow'
+  # * Go to 'Actions' -> 'Lint and test charts' -> 'Run workflow'
   # * Fill in the following:
   #   * `checkout-repo`: `<PR author>/op-scim-helm`
   #   * `checkout-ref`: <copied commit hash>


### PR DESCRIPTION
I misunderstood how to trigger a manual workflow run. The following comment from `lint-and-test.yaml` explains exactly what to do:

```yaml
  # Workflow dispatch listener to enable on-demand acceptance test runs on external PRs.
  # How to use this:
  # * Do a sanity check on the submitted PR
  # * Copy the most recent commit hash of the PR branch
  # * Go to 'Actions' -> 'Lint and test charts' -> 'Run workflow'
  # * Fill in the following:
  #   * `checkout-repo`: `<PR author>/op-scim-helm`
  #   * `checkout-ref`: <copied commit hash>
  #   * `branch`: `acceptance-tests-on-forks`
```