### PR TITLE
Update redis to use chart name

### DIFF
--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -67,7 +67,7 @@ scim:
   # config sets the configuration options
   config:
     # redisURL sets the Redis connection URL
-    redisURL: "redis://{{ .Release.Namespace }}-redis-master:6379"
+    redisURL: "redis://{{ .Chart.Name }}-redis-master:6379"
     # domain sets the allowed 1Password sign in URL. Not set by default.
     # domain: example.1password.com
     # letsEncryptDomain sets the domain to attempt to get a certificate for via Let's Encrypt.
@@ -146,6 +146,7 @@ scim:
 # redis configuration options (see upstream chart documentation and README.MD)
 redis:
   enabled: true
+  fullnameOverride: "{{ .Chart.Name }}-redis"
   image:
     registry: docker.io
     repository: bitnami/redis


### PR DESCRIPTION
This PR sets the redisURL value using the chart name instead of the namespace.

Resolves #53.
Resolves #55.