### PR TITLE
First pass at updating secrets management and ingress

### DIFF
--- a/op-scim-bridge/templates/deployment.yaml
+++ b/op-scim-bridge/templates/deployment.yaml
@@ -98,10 +98,10 @@ spec:
             - name: "OP_PORT"
               value: "{{ .Values.scim.httpPort }}"
             - name: "OP_SESSION"
-              {{- if .Values.scim.credentialsVolume }}
+              {{- if .Values.scim.credentialsVolume.enabled }}
               value: "/home/opuser/.op/{{ .Values.scim.credentialsVolume.file }}"
               {{- end }}
-              {{- if .Values.scim.credentialsSecret }}
+              {{- if .Values.scim.credentialsSecret.enabled }}
               valueFrom:
                 secretKeyRef:
                   name: {{ tpl .Values.scim.credentialsSecret.name . }}

--- a/op-scim-bridge/templates/ingress.yaml
+++ b/op-scim-bridge/templates/ingress.yaml
@@ -29,25 +29,23 @@ spec:
   {{- if and .Values.scim.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.scim.ingress.className }}
   {{- end }}
-  {{- if .Values.scim.ingress.tls }}
+  {{- with .Values.scim.ingress }}
+  {{- if .tls.enabled }}
   tls:
-    {{- range .Values.scim.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
+    - hosts: 
+        - {{ .domain | quote }}
+      # TODO: Figure out why templating this in the values file doesn't work
+      secretName: "{{ $.Chart.Name }}-bridge-tls"
+  {{- end }}
   {{- end }}
   rules:
-    {{- range .Values.scim.ingress.hosts }}
-    - host: {{ .host | quote }}
+    {{- if .Values.scim.ingress.domain }}
+    - host: {{ .Values.scim.ingress.domain | quote }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
+          - path: {{ .Values.scim.ingress.path }}
+            {{- if and .Values.scim.ingress.pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .Values.scim.ingress.pathType }}
             {{- end }}
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
@@ -60,5 +58,6 @@ spec:
               servicePort: 80
               {{- end }}
           {{- end }}
-    {{- end }}
+    {{ else }}
+      {{- fail "A domain for the deployment must be specified. This is *not* a 1Password.com address. Example: '1password-scim-bridge.yoursite.com'" }}
 {{- end }}

--- a/op-scim-bridge/templates/secret.yaml
+++ b/op-scim-bridge/templates/secret.yaml
@@ -1,7 +1,9 @@
-{{- if .Values.scim.credentialsSecret }}
-{{- if or .Values.scim.credentialsSecret.value_json .Values.scim.credentialsSecret.value_base64 }}
-{{- if and .Values.scim.credentialsSecret.value_json .Values.scim.credentialsSecret.value_base64 }}
-  {{- fail "Only one of scim.credentialsSecret.value_json and scim.credentialsSecret.value_base64 can be specified" }}
+{{- if .Values.scim.credentialsSecret.enabled }}
+{{- if and .Values.scim.credentialsSecret.enabled .Values.scim.credentialsVolume.enabled }}
+  {{- fail "Either credentialsSecret or credentialsVolume may be specified, not both"}}
+{{- end }}
+{{- if not .Values.scim.credentialsSecret.data }}
+  {{- fail "Contents of the scimsession file must be provided" }}
 {{- end }}
 apiVersion: v1
 kind: Secret
@@ -18,12 +20,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
-stringData:
+data:
   {{ .Values.scim.credentialsSecret.key }}: |-
-  {{ if .Values.scim.credentialsSecret.value_json }}
-  {{- .Values.scim.credentialsSecret.value_json | b64enc | indent 2 }}
-  {{ else }}
-  {{- .Values.scim.credentialsSecret.value_base64 | indent 2 }}
-  {{ end }}
-{{- end }}
+    {{ toJson .Values.scim.credentialsSecret.data | b64enc }}
 {{- end }}

--- a/op-scim-bridge/templates/service.yaml
+++ b/op-scim-bridge/templates/service.yaml
@@ -14,7 +14,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.scim.ingress.enable }}
   type: {{ .Values.scim.service.type }}
+  {{- else if .Values.scim.ingress.enabled }}
+  type: ClusterIP
+  {{- end }}
   selector:
     app: {{ tpl .Values.scim.name . }}
   ports:

--- a/op-scim-bridge/templates/service.yaml
+++ b/op-scim-bridge/templates/service.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.scim.ingress.enable }}
+  {{- if not .Values.scim.ingress.enabled }}
   type: {{ .Values.scim.service.type }}
   {{- else if .Values.scim.ingress.enabled }}
   type: ClusterIP

--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -51,7 +51,8 @@ scim:
     enabled: false
     className:
     domain:
-    path: \
+    path: /
+    pathType: ImplementationSpecific
     tls:
       enabled: false
       secretName: "{{ .Chart.Name }}-bridge-tls"

--- a/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/values.yaml
@@ -6,10 +6,13 @@ scim:
   version: "{{ .Chart.AppVersion }}"
   # credentialsVolume configures the SCIM bridge to access the credentials via a volume
   credentialsVolume:
+    # enables the `credentialsVolume`. Defaults to `false`. Either `credentialsSecret` or `cedentialsVolume` must be specified, but not both
+    enabled: false
     # name of the volume
     name: "{{ .Chart.Name }}-bridge-credentials"
     # name of the file to mount within the volume
     file: scimsession
+    # 
     # accessModes for the volume
     accessModes:
       - ReadWriteOnce
@@ -20,15 +23,15 @@ scim:
     # storageClass for the volume. do-block-storage is recommended for Digital Ocean. Set to "-" to set storageClass to "".
     # storageClass:
   # credentialsSecret configures the SCIM bridge to access the credentials via a secret
-  # credentialsSecret:
+  credentialsSecret:
+    # enables the `credentialsSecret`. Defaults to `true`. Either `credentialsSecret` or `cedentialsVolume` must be specified, but not both
+    enabled: true
     # name of the secret
-    # name: "{{ .Chart.Name }}-bridge-credentials"
+    name: "{{ .Chart.Name }}-bridge-credentials"
     # key of the secret
-    # key: scimsession
-    # value_json is the JSON contents of the scimsession file
-    # value_json: "{}"
-    # value_base64 is the base64 encoded contents of the scimsession file
-    # value_base64: "base64 encoded scimsession file"
+    key: scimsession
+    # data is the contents of the scimsession file, passed in as a file or an unencoded JSON string
+    data:
   # imageRepository sets the 1Password SCIM bridge image to use
   imageRepository: 1password/scim
   # imagePullPolicy sets the image pull policy
@@ -46,16 +49,12 @@ scim:
   # ingress defines the configuration for an ingress resource
   ingress:
     enabled: false
-    className: ""
-    hosts: []
-      # - host: chart-example.local
-      #   paths:
-      #     - path: /
-      #       pathType: ImplementationSpecific
-    tls: []
-      #  - secretName: chart-example-tls
-      #    hosts:
-      #      - chart-example.local
+    className:
+    domain:
+    path: \
+    tls:
+      enabled: false
+      secretName: "{{ .Chart.Name }}-bridge-tls"
   # probes configures the liveness probe used for the SCIM bridge pod
   probes:
     # liveness contains the liveness probe config


### PR DESCRIPTION
This should bring secrets storage more in line with best practices, and also cut down on the errors surrounding encoding and loading. Also a first step to eventually doing away with storing secrets on raw volumes, which is no longer recommended practice.

`scimsession` handling
Loading of the scimsession is now handled more directly and can be done in one of two ways:

1. Passed in as a single raw `json` string with no trailing newline. This can be done in a `values.yaml` file or via `--set` at runtime. Should work nicely with CI/CD pipelines.
2. Using `--set-file=scim.credentialsSecret.data=<path to file on local disk>` to avoid anything appearing in logs, and to go straight from the download screen during SCIM setup on 1Password.com
3. (Bonus). For extra brownie points you can use the 1Password cli to reference the `scimsession` file stored in a 1Password vault and deference that secret at runtime

Much delayed, but as promised https://github.com/1Password/op-scim-helm/issues/53#issuecomment-1091100056

This is only a first pass at cleanup, and mostly to address the biggest pain point of `scimsession` loading. There are more fundamental refactors to be done around scoping and how the SCIM Bridge handles external TLS forwarding, ideally all with an eye to bringing much of the logic around TLS, URL assignment, ports, etc. out of the app code and into the deployment.