### PR TITLE
Add redis Helm Chart dependency step to chart-releaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,16 @@ jobs:
           # Authenticate as the GitHub Actions bot https://api.github.com/users/github-actions%5Bbot%5D
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
           version: v3.4.1
+
+      - name: Add Helm Chart dependencies
+        run: |
+          # Add redis (used by op-scim)
+          helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
         # Fork of helm/chart-releaser-action to avoid unwanted release attempts.


### PR DESCRIPTION
This PR addresses the issue described in #68 and the linked pipeline failure.

I'll see if I can force a run of the pipeline that failed before, but this may be one of those cases where the only way to test it may be to merge it. Will post a comment with my findings.

Resolves #68.