### PR TITLE
Refactor Redis configuration to fix crash loop

### DIFF
--- a/charts/op-scim-bridge/values.yaml
+++ b/charts/op-scim-bridge/values.yaml
@@ -190,7 +190,9 @@ redis:
       limits:
         cpu: 250m
         memory: 512M
-    extraFlags: ["--maxmemory", "256mb", "--maxmemory-policy", "volatile-lru"]
+  commonConfiguration: |-
+    maxmemory 256mb
+    maxmemory-policy volatile-lru
 
 # acceptanceTests is used by the tests run during CI (see templates/tests)
 acceptanceTests:


### PR DESCRIPTION
This PR fixes a bug discovered while helping a customer deploy 1Password SCIM bridge on DigitalOcean. The marketplace app fails to deploy, and the Redis pod shows the following output in the logs:

```
*** FATAL CONFIG FILE ERROR (Redis 7.0.2) ***
Reading the configuration file, at line 11
>>> 'maxmemory 256mb "--maxmemory-policy volatile-lru"'
wrong number of arguments
```

In this PR, the configuration is passed to Redis using the `commonConfiguration` key in [the Redis common configuration parameters](https://github.com/bitnami/charts/blob/master/bitnami/redis/README.md#redis-common-configuration-parameters) rather than the `extraFlags` key in [the Redis master confiiguration](https://github.com/bitnami/charts/blob/master/bitnami/redis/README.md#redis-master-configuration-parameters), so it's a little more universal as an added bonus.