### PR TITLE
Fix repository URL, chart name READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Install the latest version of Helm. See [installing Helm](https://helm.sh/docs/i
 ### Add repository
 
 ```shell
-helm repo add 1password  https://1password.github.io/op-scim-helm
+helm repo add 1password https://1password.github.io/op-scim-helm
 helm repo update
 ```
 
 ### Install chart
 
 ```shell
-helm install my-release 1password/op-scim-bridge
+helm install my-release 1password/op-scim
 ```
 
 ### Uninstall chart
@@ -29,4 +29,4 @@ helm uninstall my-release
 
 ## Available charts
 
-* [1Password SCIM bridge](./charts/op-scim-bridge/)
+- [1Password SCIM bridge](./charts/op-scim-bridge/)

--- a/charts/op-scim-bridge/README.md
+++ b/charts/op-scim-bridge/README.md
@@ -27,7 +27,7 @@ You will need Helm installed to use this chart. Get the latest [Helm](https://gi
 ### Add repository
 
 ```shell
-helm repo add 1password https://raw.githubusercontent.com/1password/op-scim-helm/main
+helm repo add 1password https://1password.github.io/op-scim-helm
 helm repo update
 ```
 

--- a/charts/op-scim-bridge/README.md
+++ b/charts/op-scim-bridge/README.md
@@ -34,7 +34,7 @@ helm repo update
 ### Install chart
 
 ```shell
-helm install my-release 1password/op-scim-bridge
+helm install my-release 1password/op-scim
 ```
 
 ### Uninstall chart


### PR DESCRIPTION
This PR fixes a couple README values that are incorrect.

- The helm repo is at https://1password.github.io/op-scim-helm, not https://raw.githubusercontent.com/1password/op-scim-helm/main
- The chart name in the helm repo https://1password.github.io/op-scim-helm/index.yaml is `op-scim`, not `op-scim-bridge`