### PR TITLE
Use release name instead of chart name

### DIFF
--- a/charts/op-scim-bridge/Chart.yaml
+++ b/charts/op-scim-bridge/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: op-scim-bridge
-version: 2.5.0
+version: 2.5.1
 description: A Helm chart for deploying the 1Password SCIM bridge
 keywords:
   - "1Password"

--- a/charts/op-scim-bridge/values.yaml
+++ b/charts/op-scim-bridge/values.yaml
@@ -1,7 +1,7 @@
 # scim configuration options
 scim:
   # name sets the name used for the various constructs used by the SCIM bridge setup
-  name: "{{ .Chart.Name }}"
+  name: "{{ .Release.Name }}"
   # version of the SCIM bridge
   version: "{{ .Chart.AppVersion }}"
   # credentialsVolume configures the SCIM bridge to access the credentials via a volume
@@ -86,7 +86,7 @@ scim:
   # config sets the configuration options
   config:
     # redisURL sets the Redis connection URL
-    redisURL: "redis://{{ .Chart.Name }}-redis-master:6379"
+    redisURL: "redis://{{ .Release.Name }}-redis-master:6379"
     # domain sets the allowed 1Password sign in URL. Not set by default.
     # domain: example.1password.com
     # letsEncryptDomain sets the domain to attempt to get a certificate for via Let's Encrypt.
@@ -99,7 +99,7 @@ scim:
     # prettyLogs: false
   tls:
     enabled: false
-    secret: "{{ .Chart.Name }}-tls"
+    secret: "{{ .Release.Name }}-tls"
   # resource sets the requests and/or limits for the SCIM bridge pod
   resources:
     requests:


### PR DESCRIPTION
In this PR we swop from using `{{ .Chart.Name }}` for naming resources to using `{{ .Release.Name }}`. This is the more widely accepted standard, and is also what our dependency (bitnami/redis) uses.

In previous releases using any other release name than `op-scim-bridge` results in a failure where the SCIM bridge cannot connect to the redis master because of an incorrect `REDIS_URL`.

To test this release:
1. Package the changes: `helm package charts/op-scim-bridge`
2. Install the updated chart (note the release name is `my-release` and not `op-scim-bridge`):
    ```
    helm install my-release op-scim-bridge-2.5.1.tgz --create-namespace --namespace op-scim-bridge --set scim.credentialsVolume.storageClass=do-block-storage
    ```
3. Verify that the application pods are deployed correctly and that there are no errors.

Resolves #88.

Credit to @pniederlag.