### PR TITLE
Add template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report bugs and errors found while using the Helm chart.
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Your environment
+
+<!-- Version of the Helm Chart when the error occurred -->
+Chart Version:
+
+<!-- Version of the Helm you are using -->
+Helm Version:
+
+<!-- What version of Kubernetes are you deploying the chart to? -->
+Kubernetes Version:
+
+## What happened?
+<!-- Describe the bug or error -->
+
+## What did you expect to happen?
+<!-- Describe what should have happened -->
+
+## Steps to reproduce
+1. <!-- Describe Steps to reproduce the issue -->
+
+
+## Notes & Logs
+<!-- Paste any logs here that may help with debugging.
+Remember to remove any sensitive information before sharing! -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true
+contact_links:
+  - name: 1Password Community
+    url: https://1password.community/categories/scim-bridge
+    about: Ask general SCIM bridge and automated provisioning questions here.
+  - name: 1Password Support
+    url: https://support.1password.com/contact/
+    about: Create a support request.
+  - name: 1Password Security Bug Bounty
+    url: https://bugcrowd.com/agilebits
+    about: Report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature request
+about: Suggest an idea for the Helm chart.
+title: ''
+labels: feature-request
+assignees: ''
+
+---
+
+### Summary
+<!-- Briefly describe the feature in one or two sentences. You can include more details later. -->
+
+### Use cases
+<!-- Describe the use cases that make this feature useful to others.
+The description should help the reader understand why the feature is necessary.
+The better we understand your use case, the better we can evaluate the idea and help create an appropriate solution.
+
+See our guide to contributing to the project for more information on the requests that are generally considered:
+https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md
+-->
+
+### Proposed solution
+<!-- If you already have an idea for how the feature should work, use this space to describe it.
+We'll work with you to find a workable approach, and any implementation details are appreciated. -->
+
+### Is there a workaround to accomplish this today?
+<!-- If there's a way to accomplish this feature request without changes to the codebase, we'd like to hear it. -->
+
+### References and prior work
+<!-- If a similar feature was implemented in another project or tool, add a link so we can better understand your request.
+Links to relevant documentation or RFCs are also appreciated. -->
+
+<!-- * Reference 1 -->
+<!-- * Reference 2, etc -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Overview
+
+* Provide a detailed description of the changes, the problem that's being 
+addressed and how this is objectively a worthwhile addition to the project.
+
+## Changes
+
+* List the changes that you made
+
+-----------------------------------------------------------------------
+
+## Checklist
+
+- [ ] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)


### PR DESCRIPTION
This PR adds templates for reporting bugs and feature requests.

This is based on the example of the [1Password/connect-helm-charts](https://github.com/1Password/connect-helm-charts) project.

For more information see the GitHub docs on [configuring issue templates for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository).

Resolves #94.