### PR TITLE
feat: Add support for enabled, create, and named external credentials

### DIFF
--- a/charts/op-scim-bridge/templates/deployment.yaml
+++ b/charts/op-scim-bridge/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.scim.credentials.volume.enabled .Values.scim.credentials.secrets.enabled }}
+{{- fail "scim.credentials.volume.enabled and scim.credentials.secrets.enabled are mutually exclusive." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,13 +57,14 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.scim.credentialsVolume }}
+      {{- if .Values.scim.credentials.volume.enabled }}
       volumes:
-        - name: "{{ tpl .Values.scim.name . }}-credentials"
+        - name: "{{ tpl .Values.scim.credentials.volume.name . }}"
           persistentVolumeClaim:
-            claimName: {{ tpl .Values.scim.name . }}-pvc
+            claimName: "{{ tpl .Values.scim.credentials.volume.claimName . }}"
       {{- end }}
-      {{- if .Values.scim.credentialsVolume }}
+      {{- if .Values.scim.credentials.volume.enabled }}
+      {{- if .Values.scim.credentials.volume.create }}
       initContainers:
         - name: opuser-home-permissions
           image: alpine:3.16
@@ -71,11 +75,12 @@ spec:
             - "mkdir -p /home/opuser/.op && chown -R 999 /home/opuser && chmod -R 700 /home/opuser"
           volumeMounts:
             - mountPath: /home/opuser/.op
-              name: {{ tpl .Values.scim.name . }}-credentials
+              name: "{{ tpl .Values.scim.credentials.volume.name . }}"
           {{- with .Values.scim.initContainers.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- end }}
       {{- end }}
       containers:
         - name: {{ tpl .Values.scim.name . }}
@@ -98,34 +103,34 @@ spec:
             - name: "OP_PORT"
               value: "{{ .Values.scim.httpPort }}"
             - name: "OP_SESSION"
-              {{- if .Values.scim.credentialsVolume }}
-              value: "/home/opuser/.op/{{ .Values.scim.credentialsVolume.files.scimsessionFile }}"
+              {{- if .Values.scim.credentials.volume.enabled }}
+              value: "/home/opuser/.op/{{ .Values.scim.credentials.volume.files.scimsessionFile }}"
               {{- end }}
-              {{- if (.Values.scim.credentialsSecrets).scimsession }}
+              {{- if .Values.scim.credentials.secrets.enabled }}
               valueFrom:
                 secretKeyRef:
-                  name: "{{ tpl .Values.scim.name . }}-credentials"
-                  key: {{ .Values.scim.credentialsSecrets.scimsession.key }}
+                  name: "{{ tpl .Values.scim.credentials.secrets.name . }}"
+                  key: {{ .Values.scim.credentials.secrets.scimsession.key }}
               {{- end }}
             - name: "OP_WORKSPACE_SETTINGS"
-              {{- if .Values.scim.credentialsVolume }}
-              value: "/home/opuser/.op/{{ .Values.scim.credentialsVolume.files.workspaceSettingsFile }}"
+              {{- if .Values.scim.credentials.volume.enabled }}
+              value: "/home/opuser/.op/{{ .Values.scim.credentials.volume.files.workspaceSettingsFile }}"
               {{- end }}
-              {{- if (.Values.scim.credentialsSecrets).workspaceSettings }}
+              {{- if .Values.scim.credentials.secrets.enabled }}
               valueFrom:
                 secretKeyRef:
-                  name: "{{ tpl .Values.scim.name . }}-credentials"
-                  key: {{ .Values.scim.credentialsSecrets.workspaceSettings.key }}
+                  name: "{{ tpl .Values.scim.credentials.secrets.name . }}"
+                  key: {{ .Values.scim.credentials.secrets.workspaceSettings.key }}
               {{- end }}
             - name: "OP_WORKSPACE_CREDENTIALS"
-              {{- if .Values.scim.credentialsVolume }}
-              value: "/home/opuser/.op/{{ .Values.scim.credentialsVolume.files.workspaceCredentialsFile }}"
+              {{- if .Values.scim.credentials.volume.enabled }}
+              value: "/home/opuser/.op/{{ .Values.scim.credentials.volume.files.workspaceCredentialsFile }}"
               {{- end }}
-              {{- if (.Values.scim.credentialsSecrets).workspaceCredentials }}
+              {{- if .Values.scim.credentials.secrets.enabled }}
               valueFrom:
                 secretKeyRef:
-                  name: "{{ tpl .Values.scim.name . }}-credentials"
-                  key: {{ .Values.scim.credentialsSecrets.workspaceCredentials.key }}
+                  name: "{{ tpl .Values.scim.credentials.secrets.name . }}"
+                  key: {{ .Values.scim.credentials.secrets.workspaceCredentials.key }}
               {{- end }}
             - name: "OP_REDIS_URL"
               value: "{{ tpl .Values.scim.config.redisURL . }}"
@@ -164,9 +169,11 @@ spec:
             periodSeconds: 30
             initialDelaySeconds: 15
           {{- end }}
-          {{- if .Values.scim.credentialsVolume }}
+          {{- if .Values.scim.credentials.volume.enabled }}
+          {{- if .Values.scim.credentials.volume.create }}
           volumeMounts:
-            - name: {{ tpl .Values.scim.name . }}-credentials
+            - name: "{{ tpl .Values.scim.credentials.volume.name . }}"
               mountPath: "/home/opuser/.op"
               readOnly: false
+          {{- end }}
           {{- end }}

--- a/charts/op-scim-bridge/templates/persistentvolumeclaim.yaml
+++ b/charts/op-scim-bridge/templates/persistentvolumeclaim.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.scim.credentialsVolume }}
+{{- if .Values.scim.credentials.volume.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ tpl .Values.scim.name . }}-pvc
+  name: "{{ tpl .Values.scim.credentials.volume.claimName . }}"
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/application: {{ tpl .Values.scim.name . }}
@@ -14,19 +14,19 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.scim.credentialsVolume.accessModes }}
+  {{- with .Values.scim.credentials.volume.accessModes }}
   accessModes:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.scim.credentialsVolume.resources }}
+  {{- with .Values.scim.credentials.volume.resources }}
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- if .Values.scim.credentialsVolume.storageClass }}
-  {{- if (eq "-" .Values.scim.credentialsVolume.storageClass) }}
+{{- if .Values.scim.credentials.volume.storageClass }}
+  {{- if (eq "-" .Values.scim.credentials.volume.storageClass) }}
   storageClassName: '""'
   {{- else }}
-  storageClassName: "{{ .Values.scim.credentialsVolume.storageClass }}"
+  storageClassName: "{{ .Values.scim.credentials.volume.storageClass }}"
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/op-scim-bridge/templates/secret.yaml
+++ b/charts/op-scim-bridge/templates/secret.yaml
@@ -1,5 +1,10 @@
-{{- if .Values.scim.credentialsSecrets }}
-{{- range $secret := .Values.scim.credentialsSecrets }}
+{{- if .Values.scim.credentials.secrets.enabled }}
+{{- if .Values.scim.credentials.secrets.create }}
+{{- $secrets := pick .Values.scim.credentials.secrets "scimsession" "workspaceSettings" "workspaceCredentials" }}
+{{- range $secret := $secrets }}
+{{- if not (or (hasKey $secret "value_json") (hasKey $secret "value_base64")) }}
+{{- fail "If create is set one of either value_json or value_base64 is required for each secret" }}
+{{- end }}
 {{- if or $secret.value_json $secret.value_base64 }}
 {{- if and $secret.value_json $secret.value_base64 }}
 {{- fail "Only one of {{ $secret }}.value_json and {{ $secret }}.value_base64 can be specified" }}
@@ -9,7 +14,7 @@
 kind: Secret
 apiVersion: v1
 metadata:
-  name: "{{ tpl .Values.scim.name . }}-credentials"
+  name: "{{ tpl .Values.scim.credentials.secrets.name . }}"
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/application: {{ tpl .Values.scim.name . }}
@@ -22,7 +27,7 @@ metadata:
   {{- end }}
 type: Opaque
 stringData:
-  {{- range $secret := .Values.scim.credentialsSecrets }}
+  {{- range $secret := $secrets }}
   {{ $secret.key }}: |-
   {{ if $secret.value_json }}
   {{- $secret.value_json | b64enc | indent 2 }}
@@ -30,4 +35,5 @@ stringData:
   {{- $secret.value_base64 | indent 2 }}
   {{ end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/op-scim-bridge/values.yaml
+++ b/charts/op-scim-bridge/values.yaml
@@ -4,47 +4,58 @@ scim:
   name: '{{ template "common.names.fullname" . }}'
   # version of the SCIM bridge
   version: "{{ .Chart.AppVersion }}"
-  # credentialsVolume configures the SCIM bridge to access the credentials via a volume
-  credentialsVolume:
-    # name of the file to mount within the volume
-    files:
-      scimsessionFile: scimsession
-      workspaceSettingsFile: workspace-settings.json
-      workspaceCredentialsFile: workspace-credentials.json
-    # accessModes for the volume
-    accessModes:
-      - ReadWriteOnce
-    # resources configuration for the volume
-    resources:
-      requests:
-        storage: 1Gi
-    # storageClass for the volume. do-block-storage is recommended for Digital Ocean. Set to "-" to set storageClass to "".
-    # storageClass:
-  # credentialsSecrets configures the SCIM bridge to access the credentials via a secret
-  # TODO: make an "enabled" flag so these sections can both be uncommented
-  credentialsSecrets:
-    # scimsession:
-    #   # name of the secret
-    #   # key of the secret
-    #   key: scimsession
-    #   # value_json is the JSON contents of the scimsession file
-    #   value_json: "{}"
-    #   # value_base64 is the base64 encoded contents of the scimsession file
-    #   # value_base64: "base64 encoded scimsession file"
-    # workspaceSettings:
-    #   # key of the secret
-    #   key: workspace-settings
-    #   # value_json is the JSON contents of the scimsession file
-    #   value_json: "{}"
-    #   # value_base64 is the base64 encoded contents of the workspace settings file
-    #   # value_base64: "base64 encoded workspace settings file"
-    # workspaceCredentials:
-    #   # key of the secret
-    #   key: workspace-credentials
-    #   # value_json is the JSON contents of the scimsession file
-    #   value_json: "{}"
-    #   # value_base64 is the base64 encoded contents of the workspace key file
-    #   # value_base64: "base64 encoded workspace key file"
+  # configure the credentials used by the SCIM bridge
+  credentials:
+    volume:
+      # setting enabled:true configures the SCIM bridge to access the credentials via a volume
+      enabled: false
+      # create the volume if it does not exist
+      create: true
+      # name of an existing volume to use for the credentials
+      name: '{{ template "common.names.fullname" . }}-credentials'
+      claimName: '{{ template "common.names.fullname" . }}-pvc'
+      # name of the file to mount within the volume
+      files:
+        scimsessionFile: scimsession
+        workspaceSettingsFile: workspace-settings.json
+        workspaceCredentialsFile: workspace-credentials.json
+      # accessModes for the volume
+      accessModes:
+        - ReadWriteOnce
+      # resources configuration for the volume
+      resources:
+        requests:
+          storage: 1Gi
+      # storageClass for the volume. do-block-storage is recommended for Digital Ocean. Set to "-" to set storageClass to "".
+      # storageClass:
+    secrets:
+      # setting enabled:true configures the SCIM bridge to access the credentials via a secret
+      enabled: true
+      # create the secret if it does not exist
+      create: false
+      # name of the secret
+      name: '{{ template "common.names.fullname" . }}-credentials'
+      scimsession:
+        # key of the secret
+        key: scimsession
+        # value_json is the JSON contents of the scimsession file
+        # value_json: "{}"
+        # value_base64 is the base64 encoded contents of the scimsession file
+        # value_base64: "base64 encoded scimsession file"
+      workspaceSettings:
+        # key of the secret
+        key: workspace-settings
+        # value_json is the JSON contents of the scimsession file
+        # value_json: "{}"
+        # value_base64 is the base64 encoded contents of the workspace settings file
+        # value_base64: "base64 encoded workspace settings file"
+      workspaceCredentials:
+        # key of the secret
+        key: workspace-credentials
+      #   # value_json is the JSON contents of the scimsession file
+      #   value_json: "{}"
+      #   # value_base64 is the base64 encoded contents of the workspace key file
+      #   # value_base64: "base64 encoded workspace key file"
   # imageRepository sets the 1Password SCIM bridge image to use
   imageRepository: 1password/scim
   # imagePullPolicy sets the image pull policy


### PR DESCRIPTION
## Overview

The current structure of the chart makes it difficult to manage credentials without explicitly providing insecure values to the helm deployment. In order to address this shortcoming it was necessary to provide a mechanism that disables the creation of volumes and/or secrets whilst still allowing the deployment to reference either a volume or secret by name so that sub-charts can use whatever means they desire to generate credentials securely. As part of this implementation I also provided enabled fields to both volume and secret which was listed as a TODO item in source.

Fixes #87 

> TODO: Will have to update documentation referencing credentialsVolume and credentialsSecrets with a description of the `credentials.volume` and `credentials.secrets` specification.

## Changes

* List the changes that you made
* Refactored `credentialsVolume` and `credentialsSecrets` under the credentials interface
* Added enabled boolean field to volume and secrets
* Updated checks for mutual exclusion and values
* Added create flag to support externally generated volumes and secrets
-----------------------------------------------------------------------

## Checklist

- [X] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)
