### PR TITLE
Fix permissions for `home/opuser`

### DIFF
--- a/charts/op-scim-bridge/templates/deployment.yaml
+++ b/charts/op-scim-bridge/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - "/bin/sh"
             - "-c"
           args:
-            - "mkdir -p /home/opuser/.op && chown -R 999 /home/opuser && chmod -R 700 /home/opuser"
+            - "mkdir -p /home/opuser/.op && chown -R 999 /home/opuser && chmod -R 600 /home/opuser"
           volumeMounts:
             - mountPath: /home/opuser/.op
               name: {{ tpl .Values.scim.name . }}-credentials


### PR DESCRIPTION
This resolves the issues with 2.6.2.

## Overview
* Changes the deployment chart to be permission `600` rather than `700` due to upstream changes.

## Changes

* Changes permissions to resolve issue.

-----------------------------------------------------------------------

## Checklist

- [x] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)
