### PR TITLE
Fix permission error in 2.6.2

### DIFF
--- a/charts/op-scim-bridge/templates/deployment.yaml
+++ b/charts/op-scim-bridge/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - "/bin/sh"
             - "-c"
           args:
-            - "mkdir -p /home/opuser/.op && chown -R 999 /home/opuser && chmod -R 700 /home/opuser"
+            - "mkdir -p /home/opuser/.op && chown -R 999 /home/opuser && chmod -R 700 /home/opuser && umask 177 /home/opuser/.op"
           volumeMounts:
             - mountPath: /home/opuser/.op
               name: {{ tpl .Values.scim.name . }}-credentials


### PR DESCRIPTION
Changes meant that permissions were too broad in `home/opuser/.op`. My initial attempt would have fixed the problem during existing deployments, but would not have been viable in the Helm chart. While the permissions would have been valid for the `.op` folder, 1Password SCIM Bridge would not have been able to save files to the `.op` directory, resulting in a similar issue as prior to this fix. This fix solves the problem by keeping the permissions for `.op` as in the current chart, and then sets the `umask` for `.op` to ensure that newly created files have the appropriate permissions.

Resolves !3088.

-----------------------------------------------------------------------

## Checklist

- [x] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)
