### PR TITLE
Made `credentialsVolume` and `credentialsSecrets` mutually exclusive

### DIFF
--- a/charts/op-scim-bridge/README.md
+++ b/charts/op-scim-bridge/README.md
@@ -97,7 +97,7 @@ These values set available SCIM bridge configuation options. For details on the 
 
 #### credentialsVolume
 
-Note that you should configure accessing the SCIM bridge credentials through either the `credentialsVolume` or the `credentialsSecrets`, and not both.
+Note that you should configure accessing the SCIM bridge credentials through either the `credentialsVolume` or the `credentialsSecrets`, and not both.  If you set `credentialsSecrets`, then `credentialsVolume` will be ignored.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -109,13 +109,33 @@ Note that you should configure accessing the SCIM bridge credentials through eit
 
 #### credentialsSecrets
 
-Note that you should configure accessing the SCIM bridge credentials through either the `credentialsVolume` or the `credentialsSecrets`, and not both.
+Note that you should configure accessing the SCIM bridge credentials through either the `credentialsVolume` or the `credentialsSecrets`, and not both.  If you set `credentialsSecrets`, then `credentialsVolume` will be ignored.
+If `credentialsSecrets` contains `scimsession`, `workspaceSettings`, or `workspaceCredentials`, the `op-scim-bridge` pod will use `SecretKeyRef`s for the `key` in each of those entries.
+If you further specify either `value_json` or `value_base64` in those entries, the `Secret` will be created for you with these keys.  You may omit `value_json` and `value_base64` if you wish to create the secret externally and only reference it here.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | scimsession | object | `{ “name”:”op-scim-bridge-credentials”, “key”: “scimsession”, “value_json”: “{}”, “value_base64”: “base64 encoded scimsession file” }` | scimsession secret definition. |
 | workspaceSettings | object | `{ “name”:”op-scim-bridge-workspace-settings”, “key”: “workspace-settings”, “value_json”: “{}”, “value_base64”: “base64 encoded workspace settings file” }` | workspace settings secret definition. |
 | workspaceCredentials | object | `{ “name”:”op-scim-bridge-workspace-credentials”, “key”: “workspace-credentials”, “value_json”: “{}”, “value_base64”: “base64 encoded workspace credentials file” }` | workspace credentials secret definition. |
+
+
+If you create your own secret, you must name it `{scim.name}-credentials` if `scim.name` is set, otherwise `{helm-release}-credentials`.  You'll encode all the above keys (`scimsession`, `workspace-settings`, `workspace-credentials`) with double-base64-encoded values, e.g.:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: op-scim-bridge-credentials
+type: Opaque
+data:
+  scimsession: >-
+    base64encode(base64encode({contents of scimsession file}))
+  workspace-credentials: >-
+    base64encode(base64encode({contents of google cloud service account JWT}))
+  workspace-settings: >-
+    base64encode(base64encode({"actor":"admin@mydomain.com","bridgeAddress":"https://scimbridge.mydomain.com"}))
+```
 
 
 ### redis

--- a/charts/op-scim-bridge/templates/deployment.yaml
+++ b/charts/op-scim-bridge/templates/deployment.yaml
@@ -54,13 +54,13 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.scim.credentialsVolume }}
+      {{- if and .Values.scim.credentialsVolume (empty .Values.scim.credentialsSecrets) }}
       volumes:
         - name: "{{ tpl .Values.scim.name . }}-credentials"
           persistentVolumeClaim:
             claimName: {{ tpl .Values.scim.name . }}-pvc
       {{- end }}
-      {{- if .Values.scim.credentialsVolume }}
+      {{- if and .Values.scim.credentialsVolume (empty .Values.scim.credentialsSecrets) }}
       initContainers:
         - name: opuser-home-permissions
           image: alpine:3.16
@@ -98,7 +98,7 @@ spec:
             - name: "OP_PORT"
               value: "{{ .Values.scim.httpPort }}"
             - name: "OP_SESSION"
-              {{- if .Values.scim.credentialsVolume }}
+              {{- if and .Values.scim.credentialsVolume (empty .Values.scim.credentialsSecrets) }}
               value: "/home/opuser/.op/{{ .Values.scim.credentialsVolume.files.scimsessionFile }}"
               {{- end }}
               {{- if (.Values.scim.credentialsSecrets).scimsession }}
@@ -108,7 +108,7 @@ spec:
                   key: {{ .Values.scim.credentialsSecrets.scimsession.key }}
               {{- end }}
             - name: "OP_WORKSPACE_SETTINGS"
-              {{- if .Values.scim.credentialsVolume }}
+              {{- if and .Values.scim.credentialsVolume (empty .Values.scim.credentialsSecrets) }}
               value: "/home/opuser/.op/{{ .Values.scim.credentialsVolume.files.workspaceSettingsFile }}"
               {{- end }}
               {{- if (.Values.scim.credentialsSecrets).workspaceSettings }}
@@ -118,7 +118,7 @@ spec:
                   key: {{ .Values.scim.credentialsSecrets.workspaceSettings.key }}
               {{- end }}
             - name: "OP_WORKSPACE_CREDENTIALS"
-              {{- if .Values.scim.credentialsVolume }}
+              {{- if and .Values.scim.credentialsVolume (empty .Values.scim.credentialsSecrets) }}
               value: "/home/opuser/.op/{{ .Values.scim.credentialsVolume.files.workspaceCredentialsFile }}"
               {{- end }}
               {{- if (.Values.scim.credentialsSecrets).workspaceCredentials }}
@@ -164,7 +164,7 @@ spec:
             periodSeconds: 30
             initialDelaySeconds: 15
           {{- end }}
-          {{- if .Values.scim.credentialsVolume }}
+          {{- if and .Values.scim.credentialsVolume (empty .Values.scim.credentialsSecrets) }}
           volumeMounts:
             - name: {{ tpl .Values.scim.name . }}-credentials
               mountPath: "/home/opuser/.op"

--- a/charts/op-scim-bridge/templates/persistentvolumeclaim.yaml
+++ b/charts/op-scim-bridge/templates/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scim.credentialsVolume }}
+{{- if and .Values.scim.credentialsVolume (empty .Values.scim.credentialsSecrets) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/op-scim-bridge/templates/secret.yaml
+++ b/charts/op-scim-bridge/templates/secret.yaml
@@ -1,11 +1,14 @@
 {{- if .Values.scim.credentialsSecrets }}
+{{- $numSecretValues := 0 }}
 {{- range $secret := .Values.scim.credentialsSecrets }}
 {{- if or $secret.value_json $secret.value_base64 }}
+{{- $numSecretValues = add1 $numSecretValues }}
 {{- if and $secret.value_json $secret.value_base64 }}
 {{- fail "Only one of {{ $secret }}.value_json and {{ $secret }}.value_base64 can be specified" }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{ if gt $numSecretValues 0 }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -23,6 +26,7 @@ metadata:
 type: Opaque
 stringData:
   {{- range $secret := .Values.scim.credentialsSecrets }}
+  {{- if or $secret.value_json $secret.value_base64 }}
   {{ $secret.key }}: |-
   {{ if $secret.value_json }}
   {{- $secret.value_json | b64enc | indent 2 }}
@@ -30,4 +34,6 @@ stringData:
   {{- $secret.value_base64 | indent 2 }}
   {{ end }}
   {{- end }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/op-scim-bridge/values.yaml
+++ b/charts/op-scim-bridge/values.yaml
@@ -5,6 +5,7 @@ scim:
   # version of the SCIM bridge
   version: "{{ .Chart.AppVersion }}"
   # credentialsVolume configures the SCIM bridge to access the credentials via a volume
+  # NOTE: credentialsVolume will be ignored if you set credentialsSecret.  You may only use one or the other.
   credentialsVolume:
     # name of the file to mount within the volume
     files:
@@ -21,7 +22,6 @@ scim:
     # storageClass for the volume. do-block-storage is recommended for Digital Ocean. Set to "-" to set storageClass to "".
     # storageClass:
   # credentialsSecrets configures the SCIM bridge to access the credentials via a secret
-  # TODO: make an "enabled" flag so these sections can both be uncommented
   credentialsSecrets:
     # scimsession:
     #   # name of the secret


### PR DESCRIPTION
## Overview

### Problem 1
I had problems using ArgoCD to install this chart using `scim.credentialsSecrets`.  While helm properly erases `scim.credentialsVolume` if it's set to `null` in a values file or `--set` argument, ArgoCD merges them.  As a consequence the spec for `op-scim-bridge` pod includes both `value` and `valueFrom.secretKeyRef`, resulting in an invalid spec. e.g.:

```yaml
env:
- name: "OP_PORT"
  value: "{{ .Values.scim.httpPort }}"
- name: "OP_SESSION"
  value: "/home/opuser/.op/scimsession"
  valueFrom:
    secretKeyRef:
      name: "op-scim-bridge-credentials"
      key: "scimsession"
```
`deployment.yaml` had a `TODO` in it referencing possiblly creating a flag to choose between volume and secret.  I figured that since it's advised to either use `credentialsVolume` OR `credentialsSecrets`, the chart itself can make them mutually exclusive. If `credentialsSecrets` is defined, env var insertion of the filenames from `credentialsVolume` will be skipped.

### Problem 2
Even with the above change, the PVC was being created and bound to the pod when it wasn't needed.  This is especially problematic when using terraform to apply the helm chart, since the release occasionally gets forced after external changes are made.  Kube complains because the PVC is immutable, which means it's not as simple as just importing the updated release into the terraform state.  This is now changed so that the PVC is no longer created or bound when `credentialsSecrets` is set.

### Problem 3
The `credentialsSecrets` value triggers the creation of kube `Secret`s, which means the secret values must be hard coded into the release, with no opportunity to simply reference an existing secret.  This is now changed so that the `op-scim-bridge-credentials` `Secret` is only created if at least one of keys has a `value_json` or a `value_base64`.  With this change, I'm now able to create the secret with another process, and have the helm release set the `OP_SESSION`, `OP_WORKSPACE_CREDENTIALS`, and `OP_WORKSPACE_SETTINGS` to `secretKeyRef`s without actually creating or overwriting the secret.
