### PR TITLE
Add extraEnv value

### DIFF
--- a/charts/op-scim-bridge/templates/deployment.yaml
+++ b/charts/op-scim-bridge/templates/deployment.yaml
@@ -156,6 +156,9 @@ spec:
             - name: "OP_PRETTY_LOGS"
               value: "{{ .Values.scim.config.prettyLogs }}"
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.scim.httpPort }}
             - containerPort: {{ .Values.scim.httpsPort }}

--- a/charts/op-scim-bridge/values.yaml
+++ b/charts/op-scim-bridge/values.yaml
@@ -109,6 +109,11 @@ scim:
   tls:
     enabled: false
     secret: "{{ .Release.Name }}-tls"
+  # Additional environment variables for the SCIM bridge pod
+  # must be a string (multiline) so you have to add a | after extraEnv:
+  extraEnv: ""
+  #   - name: OP_TLS_KEY_FILE
+  #   - name: OP_TLS_CERT_FILE
   # resource sets the requests and/or limits for the SCIM bridge pod
   resources:
     requests:


### PR DESCRIPTION
## Overview

Allows for custom env vars in the pod to debug or work around changes in the binary not yet covered by the helm chart.
Provides support for cases like: https://github.com/1Password/scim-examples/issues/244 
No need to manually reconfigure the deployment.
Especially useful in a gitops environment without option for drift between helm and its resources.

## Changes

* Add extraEnv variable to values.yaml - default value is empty string (safe)
* Add extraEnv templating to container env section in deployment.yaml

-----------------------------------------------------------------------

## Checklist

- [x] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)
