### PR TITLE
Version bump to 2.8.4

### DIFF
--- a/charts/op-scim-bridge/Chart.yaml
+++ b/charts/op-scim-bridge/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: op-scim-bridge
-version: 2.10.4
+version: 2.10.5
 description: A Helm chart for deploying the 1Password SCIM bridge
 keywords:
   - "1Password"
@@ -17,7 +17,7 @@ maintainers:
   - name: 1Password Provisioning Team
     email: support+scim@1password.com
 icon: https://1password.com/img/logo-v1.svg
-appVersion: v2.8.3
+appVersion: v2.8.4
 dependencies:
   - name: redis
     version: ~17


### PR DESCRIPTION
## Overview

* This is a normal version bump to SCIM version 2.8.4

This is a patch release primarily to provide clear instructions when provisioning users with an invalid domain.

Find the [changelog here](https://app-updates.agilebits.com/product_history/SCIM#v208041)

## Changes

* Version bump to SCIM version 2.8.4
* No changes to the chart itself.
* Note that helm dependancies are not being updated due to a template issue with redis failing linting rules. See [this PR](https://github.com/1Password/op-scim-helm/pull/132) and [here](https://github.com/1Password/op-scim-helm/actions/runs/6252696771/job/16978563327)

-----------------------------------------------------------------------

## Checklist

- [X] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)
