### PR TITLE
Disable Redis RDB snapshots

### DIFF
--- a/charts/op-scim-bridge/values.yaml
+++ b/charts/op-scim-bridge/values.yaml
@@ -195,6 +195,8 @@ redis:
   commonConfiguration: |-
     maxmemory 256mb
     maxmemory-policy volatile-lru
+    # Disable RDB persistence
+    save ""
   master:
     kind: Deployment
     # prefer to schedule redis and SCIM bridge pods on separate nodes


### PR DESCRIPTION
## Overview

The default Redis configuration persists data to the Pod that is not saved to persistent storage. The frequency and size of snapshots both increase as keys are added to Redis:
* every hour, if at least 1 change was performed
* every 5 minutes, if at least 100 changes were performed
* every minute, if at least 10,000 changes were performed

While the full impact is not known and has not been investigated, it's suspected that writing the full database to disk may be causing performance issues at scale for large provisioning events. Since Redis is configured as a data cache, this data is not needed or expected to be backed up or restored, and these snapshots are not persisted to disk anyway, the snapshots are redundant at best, and can be disabled with no risk to performance or integrity.

## Changes

* Added a line (and associated comment) to the Redis configuration in `values.yaml` to disable RDB snapshots.

-----------------------------------------------------------------------

## Checklist

- [X] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)
