### PR TITLE
Disable PVC for redis

### DIFF
--- a/charts/op-scim-bridge/values.yaml
+++ b/charts/op-scim-bridge/values.yaml
@@ -213,6 +213,8 @@ redis:
                     values:
                       - op-scim-bridge
               topologyKey: "kubernetes.io/hostname"
+    persistence:
+      enabled : false
     resources:
       requests:
         cpu: 125m

--- a/charts/op-scim-bridge/values.yaml
+++ b/charts/op-scim-bridge/values.yaml
@@ -214,7 +214,7 @@ redis:
                       - op-scim-bridge
               topologyKey: "kubernetes.io/hostname"
     persistence:
-      enabled : false
+      enabled: false
     resources:
       requests:
         cpu: 125m


### PR DESCRIPTION
## Overview

* By default, [redis mounts a persistent volume](https://github.com/bitnami/charts/tree/main/bitnami/redis#persistence). Since this creates an error when a persistent volume is not created for the deployment, we're setting this option to false.

## Changes

* set `redis.master.persistence.enabled` to false in `values.yaml` file
-----------------------------------------------------------------------

## Checklist

- [x] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)
