### PR TITLE
Enable OCI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,3 +38,4 @@ jobs:
           charts_dir: charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          HELM_EXPERIMENTAL_OCI: 1


### PR DESCRIPTION
## Changes

* Enable OCI

Our chart-releaser stage of the pipeline uses [this stale fork](https://github.com/florisvdg/chart-releaser-action/tree/simplified-change-detection) of the stock Helm action, which is currently pinned at Helm 3.4.0. When we upgrade to Helm 3.8, OCI will be enabled by default and we can remove this.

-----------------------------------------------------------------------

## Checklist

- [X] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)
