### PR TITLE
Use helm/chart-releaser-action

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Set up chart test CLI
         uses: helm/chart-testing-action@v2.1.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,11 +31,8 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
-        # Fork of helm/chart-releaser-action to avoid unwanted release attempts.
-        # Upstream PR: https://github.com/helm/chart-releaser-action/pull/80
-        uses: florisvdg/chart-releaser-action@v1.3.0
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          HELM_EXPERIMENTAL_OCI: 1


### PR DESCRIPTION
## Overview

* Update the `lint` and `release` stages of the helm chart.

## Changes

* Update to Python 3.8 as 3.7 is nearing end of life and was encountering [this error](https://github.com/1Password/op-scim-helm/actions/runs/12416036466/job/34663736016)
* Update from a forked version called `florisvdg/chart-releaser-action@v1.3.0` to the original library `helm/chart-releaser-action@v1.6.0`. This fork was made 5+ years ago to fix a problem regarding releases happening unexpectedly. However, changes have been made to the package since, and for our use case we rarely merge to the target branch (`main`) unless we are wanting a release done. I'd like to see if we can get back to using the maintained library. 
* `HELM_EXPERIMENTAL_OCI: 1` was removed as this was to enable OCI repositories, something done by default after helm version `3.8`.

-----------------------------------------------------------------------

## Checklist

- [X] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)
