### PR TITLE
Add confirmationInterval config option

### DIFF
--- a/charts/op-scim-bridge/templates/deployment.yaml
+++ b/charts/op-scim-bridge/templates/deployment.yaml
@@ -156,6 +156,10 @@ spec:
             - name: "OP_PRETTY_LOGS"
               value: "{{ .Values.scim.config.prettyLogs }}"
             {{- end }}
+            {{- if .Values.scim.config.confirmationInterval }}
+            - name: "OP_CONFIRMATION_INTERVAL"
+              value: "{{ .Values.scim.config.confirmationInterval }}"
+            {{- end }}
           ports:
             - containerPort: {{ .Values.scim.httpPort }}
             - containerPort: {{ .Values.scim.httpsPort }}

--- a/charts/op-scim-bridge/values.yaml
+++ b/charts/op-scim-bridge/values.yaml
@@ -106,6 +106,9 @@ scim:
     # jsonLogs: false
     # prettyLogs enables colorized log output
     # prettyLogs: false
+    # confirmationInterval sets the interval (in seconds) for the ConfirmationWatcher
+    # to automatically confirm users who have accepted their invite. Default: 300, Minimum: 30
+    # confirmationInterval: 300
   tls:
     enabled: false
     secret: "{{ .Release.Name }}-tls"


### PR DESCRIPTION
## Summary

- Add `scim.config.confirmationInterval` mapped to the `OP_CONFIRMATION_INTERVAL` environment variable
- Follows the same conditional pattern used by existing config options (`jsonLogs`, `prettyLogs`, `debug`, etc.)
- Commented out by default in `values.yaml` with documentation of the default (300s) and minimum (30s) values

Closes #164