### PR TITLE
Add optional Gateway API HTTPRoute support

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -82,5 +82,10 @@ jobs:
       - name: Spin up local Kubernetes cluster
         uses: helm/kind-action@v1.9.0
 
+      # Gateway API CRDs are not bundled with kind, so install them before
+      # ct install can apply the HTTPRoute rendered by ci/httproute-values.yaml.
+      - name: Install Gateway API CRDs
+        run: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+
       - name: Deploy and run acceptance tests
         run: ct install --config ct.yaml

--- a/charts/op-scim-bridge/Chart.yaml
+++ b/charts/op-scim-bridge/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: op-scim-bridge
-version: 2.11.12
+version: 2.12.0
 description: A Helm chart for deploying the 1Password SCIM bridge
 keywords:
   - "1Password"

--- a/charts/op-scim-bridge/ci/httproute-values.yaml
+++ b/charts/op-scim-bridge/ci/httproute-values.yaml
@@ -1,0 +1,37 @@
+# CI fixture exercising the optional Gateway API HTTPRoute path.
+# Mirrors with-scim-values.yaml so the SCIM bridge installs cleanly, then turns
+# the HTTPRoute on so `ct install` validates the rendered resource against the
+# Gateway API CRDs installed into the kind cluster (see lint-and-test.yaml).
+scim:
+
+  credentials:
+    volume:
+      enabled: false
+    secret:
+      scimsession:
+        key: scimsession
+        value_json: '{}'
+      workspaceSettings:
+        key: workspace-settings
+        value_json: '{}'
+      workspaceCredentials:
+        key: workspace-credentials
+        value_json: '{}'
+  service:
+    enabled: true
+    type: NodePort
+  probes:
+    liveness:
+      enabled: false
+  config:
+    redisURL: "redis://{{ .Release.Namespace }}-redis-master:6379"
+  # Enable the HTTPRoute. The parentRef Gateway need not exist for the resource
+  # to be admitted; this fixture only verifies the rendered HTTPRoute applies
+  # against the Gateway API CRDs.
+  httproute:
+    enabled: true
+    parentRefs:
+      - name: op-scim-ci-gateway
+        namespace: gateway-system
+    hostnames:
+      - scim.ci.example.com

--- a/charts/op-scim-bridge/templates/httproute.yaml
+++ b/charts/op-scim-bridge/templates/httproute.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.scim.httproute.enabled -}}
+{{- $name := tpl .Values.scim.name . -}}
+apiVersion: {{ .Values.scim.httproute.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: HTTPRoute
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ $name }}
+    {{- with .Values.scim.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.scim.httproute.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.scim.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.scim.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.scim.httproute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.scim.httproute.rules }}
+    {{- toYaml .Values.scim.httproute.rules | nindent 4 }}
+    {{- else }}
+    - matches:
+        - path:
+            type: {{ .Values.scim.httproute.matches.path.type | default "PathPrefix" }}
+            value: {{ .Values.scim.httproute.matches.path.value | default "/" | quote }}
+      {{- with .Values.scim.httproute.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ printf "%s-svc" $name }}
+          port: {{ .Values.scim.httproute.backendPort | default 80 }}
+    {{- end }}
+{{- end }}

--- a/charts/op-scim-bridge/values.yaml
+++ b/charts/op-scim-bridge/values.yaml
@@ -85,6 +85,38 @@ scim:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+  # httproute defines the configuration for a Gateway API HTTPRoute resource,
+  # an alternative to ingress for Gateway API environments
+  httproute:
+    # enabled determines whether to create the HTTPRoute resource
+    enabled: false
+    # apiVersion overrides the HTTPRoute apiVersion (e.g. gateway.networking.k8s.io/v1beta1)
+    apiVersion: gateway.networking.k8s.io/v1
+    # annotations adds additional annotations to the HTTPRoute
+    annotations: {}
+    # labels adds additional labels to the HTTPRoute
+    labels: {}
+    # parentRefs references the Gateway(s) this route attaches to
+    parentRefs:
+      []
+      # - name: example-gateway
+      #   namespace: gateway-system
+      #   sectionName: https
+    # hostnames sets the hostnames that match this route
+    hostnames:
+      []
+      # - scim.example.com
+    # matches sets the default rule's match conditions (ignored when rules is set)
+    matches:
+      path:
+        type: PathPrefix
+        value: /
+    # backendPort sets the Service port the default rule routes to (80 = http, 443 = https)
+    backendPort: 80
+    # filters applies to the default rule (e.g. RequestHeaderModifier). Ignored when rules is set
+    filters: []
+    # rules overrides the generated default rule entirely for advanced routing
+    rules: []
   # probes configures the liveness probe used for the SCIM bridge pod
   probes:
     # liveness contains the liveness probe config


### PR DESCRIPTION
## Overview

This adds an optional Gateway API `HTTPRoute` resource to the chart as an alternative to the existing `Ingress`, addressing #163. With the sunset of ingress-nginx, many users are migrating to Gateway API; this lets them route traffic to the SCIM bridge without configuring an HTTPRoute separately from the chart. It is disabled by default (`scim.httproute.enabled: false`), so existing deployments are unaffected.

## Changes

* Add `templates/httproute.yaml`, gated on `scim.httproute.enabled` (default `false`), mirroring the conventions of `templates/ingress.yaml` (name, namespace, `app.kubernetes.io/component` label, `<name>-svc` backend on port 80).
* Add the `scim.httproute` block to `values.yaml`: `parentRefs`, `hostnames`, a default `PathPrefix /` match, a configurable `backendPort`, `filters`, a full `rules` override for advanced routing, plus `apiVersion`, `annotations`, and `labels` overrides.
* Bump chart `version` 2.11.12 → 2.12.0 (additive, minor).

Validated with `helm lint` and `ct lint` (both pass). Rendered in four scenarios:
- disabled (default) → no output, so `ct install` needs no Gateway API CRDs;
- enabled with `parentRefs`/`hostnames` → default rule routes `/` to `<name>-svc:80`;
- `v1beta1` apiVersion + `backendPort: 443` + a `RequestHeaderModifier` filter;
- a full custom multi-rule `rules` override.

related: #163

## Checklist

- [x] review the [guide to contributing](https://github.com/1Password/op-scim-helm/blob/main/CONTRIBUTING.md)
